### PR TITLE
frontmatter: add created_at/updated_at/updated_by (closes #7)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,7 +1,9 @@
 ---
 type: reference
 description: "FAQ about plugin behavior - session scoping, vault sharing, and related questions"
-created: 2026-04-30
+created_at: 2026-04-30T00:00:00+08:00
+updated_at: 2026-05-03T00:00:00+08:00
+updated_by: init
 project: claude-obsidian-memory
 ---
 

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -1,7 +1,9 @@
 ---
 type: reference
 description: "Explains the three lifecycle hooks (SessionStart, UserPromptSubmit, SessionEnd) and how the plugin operates"
-created: 2026-04-30
+created_at: 2026-04-30T00:00:00+08:00
+updated_at: 2026-05-03T00:00:00+08:00
+updated_by: init
 project: claude-obsidian-memory
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ---
 type: reference
 description: "Overview of obsidian-memory plugin - vault-backed persistent memory for Claude Code"
-created: 2026-04-30
+created_at: 2026-04-30T00:00:00+08:00
+updated_at: 2026-05-03T00:00:00+08:00
+updated_by: init
 project: claude-obsidian-memory
 ---
 
@@ -14,7 +16,7 @@ A Claude Code plugin that turns a markdown directory into Claude's persistent me
 Claude Code's per-project auto-memory (`~/.claude/projects/*/memory/`) is siloed and not editable in any UI. This plugin replaces it with a vault-backed system:
 
 - **Transparent memory.** Nothing is hidden in a database or vector index — every fact the agent recalls is a file you can open and correct. Fixing a wrong memory is a text edit, not a prompt negotiation.
-- **Frontmatter as source of truth.** Every note declares `type`, `description`, `created` (and `project` when scoped). The plugin writes those fields automatically and derives everything else (recall, summaries, audits) from them — no index to maintain.
+- **Frontmatter as source of truth.** Every note declares `type`, `description`, `created_at`, `updated_at`, `updated_by` (and `project` when scoped). The plugin writes those fields automatically and derives everything else (recall, summaries, audits) from them — no index to maintain.
 - **Git-tracked.** Every memory write is a diff. Auto-commit on by default; auto-push opt-in.
 - **Obsidian-friendly, not Obsidian-required.** The vault is just markdown — search runs in pure Python. Obsidian.app adds a UI but no plugin-required functionality.
 - **Three lifecycle hooks + two skills.** `SessionStart` loads context, `UserPromptSubmit` runs a proactive retrieval gate (description-anchored), and two agent-driven skills cover reads and writes:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,7 +1,9 @@
 ---
 type: reference
 description: "Troubleshooting guide for common obsidian-memory plugin issues with diagnosis steps"
-created: 2026-04-30
+created_at: 2026-04-30T00:00:00+08:00
+updated_at: 2026-05-03T00:00:00+08:00
+updated_by: init
 project: claude-obsidian-memory
 ---
 
@@ -48,7 +50,7 @@ Reports config, vault, prereqs, binary location, search smoke-test, overview cac
 - Run `/obsidian-memory:project list` and confirm the repo shows `[on]`. If it shows `[off]`, run `/obsidian-memory:project enable` from inside the repo. If it's missing entirely, the registration prompt was never answered — start a fresh session in the repo or run `enable` directly.
 - The registry keys on the repo's git toplevel (`git rev-parse --show-toplevel`). If you've moved the repo, the old path is stale; `remove` it and re-`enable` from the new location.
 - Confirm the docs aren't all boilerplate (`LICENSE*`, `CHANGELOG*`, `CODE_OF_CONDUCT*`, `SECURITY*`, top-level dotfile dirs) — those are filtered out of the corpus.
-- Project-vault notes need plugin frontmatter to appear in the overview. `obsidian-memory init-project` runs silently each SessionStart for enabled repos and backfills any new files; if a file is missing from the overview, check that it has `type:`/`description:`/`created:`/`project:` in its frontmatter.
+- Project-vault notes need plugin frontmatter to appear in the overview. `obsidian-memory init-project` runs silently each SessionStart for enabled repos and backfills any new files; if a file is missing from the overview, check that it has `type:`/`description:`/`created_at:`/`project:` in its frontmatter.
 
 **Scanning the vault for leaked credentials**
 

--- a/skills/save-memory/SKILL.md
+++ b/skills/save-memory/SKILL.md
@@ -97,8 +97,10 @@ Single type:
 ---
 type: decision
 description: "one-line hook"
-created: YYYY-MM-DD
-project: <name>     # only if project-scoped
+created_at: 2026-05-03T22:30:00+08:00   # ISO 8601, current local time with offset
+updated_at: 2026-05-03T22:30:00+08:00   # same as created_at on first write
+updated_by: skill                        # this skill is the writer
+project: <name>                          # only if project-scoped
 ---
 ```
 
@@ -108,10 +110,14 @@ Multi-type (note genuinely spans axes — first type drives routing):
 ---
 type: [findings, decision]
 description: "one-line hook"
-created: YYYY-MM-DD
+created_at: 2026-05-03T22:30:00+08:00
+updated_at: 2026-05-03T22:30:00+08:00
+updated_by: skill
 project: <name>
 ---
 ```
+
+`created_at` / `updated_at` are ISO 8601 with local offset — get the value from `date +%Y-%m-%dT%H:%M:%S%z | sed 's/\(..\)$/:\1/'` (or the equivalent helper your shell exposes). Use `updated_by: skill` since save-memory is the actor. When you EXTEND an existing note (smallest edit on user correction), bump `updated_at` to now and set `updated_by: skill`; leave `created_at` alone.
 
 Always wrap `description:` in double quotes — descriptions commonly contain `:`, `[[wikilinks]]`, or `[brackets]`, all of which break unquoted YAML and silently truncate the description in the auto-overview. Escape embedded `"` as `\"`.
 

--- a/skills/vault-search/SKILL.md
+++ b/skills/vault-search/SKILL.md
@@ -21,6 +21,7 @@ The vault has three lookup paths. Pick by the shape of the query:
   [--type <preference|reference|findings|decision|learning|tool|journal>] \
   [--path-prefix <Tools|Notes|Journals|Journals/<project>>] \
   [--created-after YYYY-MM-DD] \
+  [--updated-after YYYY-MM-DD] \
   [--project-vault $CLAUDE_PROJECT_DIR] \
   [--json]
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -369,10 +369,8 @@ fn migrate_corpus(root: &Path, files: &[PathBuf]) -> usize {
         // the YAML well-formed.
         let new_block = format!("---\n{new_inner}\n---\n");
         let new_text = format!("{new_block}{body}");
-        if new_text != text {
-            if std::fs::write(f, new_text.as_bytes()).is_ok() {
-                written += 1;
-            }
+        if new_text != text && std::fs::write(f, new_text.as_bytes()).is_ok() {
+            written += 1;
         }
     }
     written

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,10 +1,15 @@
 //! Full Obsidian vault integrity audit — port of scripts/audit.py.
 //!
 //! Reports:
-//!   - Frontmatter completeness (type, description, created; + project for project-vault)
+//!   - Frontmatter completeness (type, description, created_at; + project for project-vault)
 //!   - Broken wikilinks (target file not found)
 //!   - Orphan notes (no incoming wikilink, excluding README.md)
 //!   - Duplicate basenames (bare wikilinks become ambiguous)
+//!
+//! With `--fix-frontmatter`, migrates legacy `created:` (date-only) to
+//! `created_at:` (ISO 8601 with local offset, sourced from each note's git
+//! first-commit timestamp; falls back to file mtime), and adds
+//! `updated_at` + `updated_by: audit` when missing.
 //!
 //! Known divergence from Python: the optional `pyyaml` deep-validation pass
 //! is not ported. Python only runs it when pyyaml happens to be installed,
@@ -13,9 +18,10 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::Result;
-use chrono::Local;
+use chrono::{DateTime, Local};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
@@ -25,6 +31,7 @@ use crate::project_docs::enumerate_project_docs;
 use crate::vault::frontmatter::{
     FRONTMATTER_RE, VALID_TYPES, note_types, parse_frontmatter,
 };
+use crate::vault::timestamps;
 use crate::vault::walk::{absolute, collect_md_files, expand_user, resolve_vault};
 
 static WIKILINK_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[\[([^\]]+)\]\]").expect("wikilink regex"));
@@ -72,10 +79,17 @@ pub fn run(args: AuditArgs) -> Result<i32> {
     let has_project_vault = args.project_vault.is_some();
     let mut reports: Vec<CorpusReport> = Vec::new();
 
+    let personal_files = collect_md_files(&vault);
+    if args.fix_frontmatter {
+        let n = migrate_corpus(&vault, &personal_files);
+        if n > 0 {
+            eprintln!("[audit --fix-frontmatter] migrated {n} note(s) in {}", vault.display());
+        }
+    }
     reports.push(audit_corpus(
         if has_project_vault { "personal" } else { "" },
         &vault,
-        &collect_md_files(&vault),
+        &personal_files,
         false,
     ));
 
@@ -85,6 +99,13 @@ pub fn run(args: AuditArgs) -> Result<i32> {
             eprintln!("project-vault not found at: {}", project_root.display());
             return Ok(1);
         }
+        let project_files = enumerate_project_docs(&project_root);
+        if args.fix_frontmatter {
+            let n = migrate_corpus(&project_root, &project_files);
+            if n > 0 {
+                eprintln!("[audit --fix-frontmatter] migrated {n} note(s) in {}", project_root.display());
+            }
+        }
         let label = format!(
             "project:{}",
             project_root.file_name().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default()
@@ -92,7 +113,7 @@ pub fn run(args: AuditArgs) -> Result<i32> {
         reports.push(audit_corpus(
             &label,
             &project_root,
-            &enumerate_project_docs(&project_root),
+            &project_files,
             true,
         ));
     }
@@ -193,14 +214,27 @@ fn audit_corpus(label: &str, root: &Path, files: &[PathBuf], project_required: b
             fm_issues.push(FmIssue { file: rel_str.clone(), issue: "no frontmatter block".into() });
         } else {
             let fm_ref = fm.as_ref();
-            let mut required: Vec<&str> = vec!["type", "description", "created"];
+            // (canonical, legacy_aliases). `created_at` accepts the legacy
+            // `created:` (date-only) so unmigrated notes don't all flag missing.
+            let mut required: Vec<(&str, &[&str])> = vec![
+                ("type", &[][..]),
+                ("description", &[][..]),
+                ("created_at", &["created"][..]),
+            ];
             if project_required {
-                required.push("project");
+                required.push(("project", &[][..]));
             }
-            for k in &required {
-                let present = fm_ref.map(|m| m.contains_key(*k)).unwrap_or(false);
+            for (canonical, aliases) in &required {
+                let present = fm_ref
+                    .map(|m| {
+                        m.contains_key(*canonical) || aliases.iter().any(|a| m.contains_key(*a))
+                    })
+                    .unwrap_or(false);
                 if !present {
-                    fm_issues.push(FmIssue { file: rel_str.clone(), issue: format!("missing `{k}`") });
+                    fm_issues.push(FmIssue {
+                        file: rel_str.clone(),
+                        issue: format!("missing `{canonical}`"),
+                    });
                 }
             }
             // Type validity (after the `missing` check so empty + missing both surface).
@@ -276,6 +310,159 @@ fn audit_corpus(label: &str, root: &Path, files: &[PathBuf], project_required: b
         orphan_notes: orphans,
         duplicate_basenames: duplicates,
     }
+}
+
+/// Rewrite each note's frontmatter to the new schema where applicable:
+///   - rename legacy `created:` (date-only) to `created_at:` (datetime + offset)
+///     using git first-commit timestamp; fall back to file mtime
+///   - add `updated_at` + `updated_by: audit` when missing
+///
+/// Returns the number of files written. Skips README.md (no frontmatter).
+fn migrate_corpus(root: &Path, files: &[PathBuf]) -> usize {
+    let now = timestamps::now_iso8601_local();
+    let mut written = 0usize;
+    for f in files {
+        if f.file_name().map(|n| NAVIGATION_NAMES.iter().any(|nav| *nav == n)).unwrap_or(false) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(f) else { continue };
+        let Some(m) = FRONTMATTER_RE.captures(&text) else { continue };
+        let whole = m.get(0).expect("group 0").as_str();
+        let inner = m.get(1).expect("group 1").as_str();
+        let body = &text[whole.len()..];
+
+        let fm = match parse_frontmatter(&text) {
+            Some(fm) => fm,
+            None => continue,
+        };
+        let has_created_at = fm.contains_key("created_at");
+        let has_legacy_created = fm.contains_key("created");
+        let has_updated_at = fm.contains_key("updated_at");
+        let has_updated_by = fm.contains_key("updated_by");
+
+        let needs_rename = !has_created_at && has_legacy_created;
+        let needs_updated = !has_updated_at || !has_updated_by;
+        if !needs_rename && !needs_updated {
+            continue;
+        }
+
+        let created_at_value = if needs_rename {
+            git_first_commit_iso(root, f).unwrap_or_else(|| {
+                file_mtime_iso(f).unwrap_or_else(|| now.clone())
+            })
+        } else {
+            String::new()
+        };
+
+        let new_inner = rewrite_frontmatter(
+            inner,
+            needs_rename,
+            &created_at_value,
+            !has_updated_at,
+            &now,
+            !has_updated_by,
+            "audit",
+        );
+
+        // Preserve the original block delimiters exactly: only the inner text
+        // is rewritten. We always emit a trailing newline before `---` to keep
+        // the YAML well-formed.
+        let new_block = format!("---\n{new_inner}\n---\n");
+        let new_text = format!("{new_block}{body}");
+        if new_text != text {
+            if std::fs::write(f, new_text.as_bytes()).is_ok() {
+                written += 1;
+            }
+        }
+    }
+    written
+}
+
+/// Line-level rewrite that preserves key order and untouched lines. Renames
+/// `created:` → `created_at:` when `rename_created`, and appends `updated_at`
+/// / `updated_by` lines when those keys are missing.
+fn rewrite_frontmatter(
+    inner: &str,
+    rename_created: bool,
+    created_at_value: &str,
+    add_updated_at: bool,
+    updated_at_value: &str,
+    add_updated_by: bool,
+    actor: &str,
+) -> String {
+    let mut out_lines: Vec<String> = Vec::new();
+    for raw_line in inner.split('\n') {
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+        if rename_created {
+            if let Some(rest) = strip_key_prefix(line, "created") {
+                // Drop the legacy date value, emit the new key with the
+                // datetime sourced from git. Discard `rest` (the old date)
+                // so we don't double-record it.
+                let _ = rest;
+                out_lines.push(format!("created_at: {created_at_value}"));
+                continue;
+            }
+        }
+        out_lines.push(line.to_string());
+    }
+    // Strip trailing blank lines so appended fields sit flush against the block.
+    while matches!(out_lines.last().map(|s| s.trim().is_empty()), Some(true)) {
+        out_lines.pop();
+    }
+    if add_updated_at {
+        out_lines.push(format!("updated_at: {updated_at_value}"));
+    }
+    if add_updated_by {
+        out_lines.push(format!("updated_by: {actor}"));
+    }
+    out_lines.join("\n")
+}
+
+/// Match `^(\s*)<key>\s*:\s*(.*)$` and return the value tail. Returns None if
+/// the line is indented (it would be a block-list item, not a top-level key).
+fn strip_key_prefix<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    if line.starts_with(' ') || line.starts_with('\t') {
+        return None;
+    }
+    let rest = line.strip_prefix(key)?;
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix(':')?;
+    Some(rest.trim_start())
+}
+
+/// Get the ISO 8601 (local-offset) timestamp of the commit that first added
+/// this file, by shelling out to `git log`. Returns None if the file is
+/// untracked or git is unavailable.
+fn git_first_commit_iso(repo_root: &Path, file: &Path) -> Option<String> {
+    let rel = file.strip_prefix(repo_root).ok()?;
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["log", "--diff-filter=A", "--follow", "--format=%aI", "--"])
+        .arg(rel)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    // `--diff-filter=A --follow` can still emit multiple lines for renames; the
+    // last line is the original-add commit.
+    let ts = stdout.lines().last()?.trim().to_string();
+    if ts.is_empty() {
+        return None;
+    }
+    // Re-format to %:z (`+HH:MM`) so emitted timestamps are uniform.
+    DateTime::parse_from_rfc3339(&ts)
+        .ok()
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%:z").to_string())
+}
+
+fn file_mtime_iso(file: &Path) -> Option<String> {
+    let meta = std::fs::metadata(file).ok()?;
+    let mt = meta.modified().ok()?;
+    let dt: DateTime<Local> = mt.into();
+    Some(dt.format("%Y-%m-%dT%H:%M:%S%:z").to_string())
 }
 
 fn extract_wikilinks(body: &str) -> Vec<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,12 +71,20 @@ pub struct VaultSearchArgs {
     /// Space-separated keywords; matched against path, frontmatter, body.
     #[arg(long)]
     pub keywords: Option<String>,
-    /// ISO date YYYY-MM-DD; only notes with frontmatter `created:` >= this date.
+    /// ISO 8601 datetime (`2026-05-02T14:30:00+08:00`) or date (`2026-05-02`);
+    /// only notes with frontmatter `created_at:` >= this. A bare date is
+    /// interpreted as local-midnight. Legacy `created:` (date-only) still matches.
     #[arg(long = "created-after")]
     pub created_after: Option<String>,
-    /// ISO date YYYY-MM-DD; only notes with `created:` <= this date.
+    /// ISO 8601 datetime or date; only notes with `created_at:` <= this.
     #[arg(long = "created-before")]
     pub created_before: Option<String>,
+    /// ISO 8601 datetime or date; only notes with frontmatter `updated_at:` >= this.
+    #[arg(long = "updated-after")]
+    pub updated_after: Option<String>,
+    /// ISO 8601 datetime or date; only notes with `updated_at:` <= this.
+    #[arg(long = "updated-before")]
+    pub updated_before: Option<String>,
     /// Max results (default 50).
     #[arg(long, default_value_t = 50)]
     pub limit: usize,
@@ -219,6 +227,12 @@ pub struct AuditArgs {
     /// Emit JSON instead of markdown.
     #[arg(long)]
     pub json: bool,
+    /// Migrate frontmatter on each note: rename legacy `created:` (date-only) to
+    /// `created_at:` (ISO 8601 with local offset, sourced from git first-commit
+    /// timestamp; falls back to file mtime). Adds `updated_at` + `updated_by: audit`
+    /// when missing. Rewrites only the frontmatter block.
+    #[arg(long = "fix-frontmatter")]
+    pub fix_frontmatter: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hook/session_end.rs
+++ b/src/hook/session_end.rs
@@ -238,7 +238,7 @@ Do steps 1-3 first. Step 4 (the journal) is written last so its bullets can refe
              → {project_dir}/<matched-folder>/<slug>.md  (with project: from the registry)
         2. Otherwise → {vault}/Notes/<slug>.md  (with `project: {project_name}` if project-scoped)
 
-   Frontmatter on every new note: type, description, created (+ project when scoped). `type:` is either a single string (`type: decision`) or a YAML list (`type: [findings, decision]`).
+   Frontmatter on every new note: type, description, created_at, updated_at, updated_by (+ project when scoped). Set `created_at` and `updated_at` to the current local time in ISO 8601 with offset (e.g. `2026-05-03T22:30:00+08:00`). Set `updated_by: hook` (this review IS the hook). When you MODIFY an existing note in step 2, bump `updated_at` to now and set `updated_by: hook`. `type:` is either a single string (`type: decision`) or a YAML list (`type: [findings, decision]`).
 
    Always wrap the `description:` value in double quotes (e.g. `description: "one-line hook"`). Descriptions often contain `:`, `[[wikilinks]]`, or `[brackets]` — unquoted, these break YAML parsing. Escape any embedded `"` as `\"`. This rule also applies when you rewrite an existing note's `description` (step 2) or the journal's day-summary `description` (step 4).
 
@@ -256,7 +256,7 @@ Do steps 1-3 first. Step 4 (the journal) is written last so its bullets can refe
 
    Per-source checks:
 
-   - (a) + (b): frontmatter completeness (type, description, created; + project when project-scoped); every [[wikilink]] resolves; description-vs-body drift (rewrite description on drift, smallest edit).
+   - (a) + (b): frontmatter completeness (type, description, created_at; + project when project-scoped); every [[wikilink]] resolves; description-vs-body drift (rewrite description on drift, smallest edit). On any rewrite, bump `updated_at` to now and set `updated_by: hook`.
 
    - (c) Vault file changes — BACKLINK RECONCILIATION:
        * RENAMED (old → new) → `"{bin}" vault --vault {vault} incoming-wikilinks --target <old>` to find every note linking to the OLD path. Auto-rewrite each occurrence to the NEW path (smallest edit; preserve any |alias text). For bare basename links, prefer the new basename. List rewrites under "## Backlink rewrites".
@@ -270,9 +270,9 @@ Do steps 1-3 first. Step 4 (the journal) is written last so its bullets can refe
 
    Journals are scoped one-file-per-project-per-day: the directory `{project_name}/` segregates this project's day from any other project's day. Use the `Write` tool — it creates parent directories automatically.
 
-   New file: frontmatter (type=journal, description=<one-line day summary>, project={project_name}, created={today}) + "## Session {now}" + 3-6 bullets covering work, decisions, learnings.
+   New file: frontmatter (type=journal, description=<one-line day summary>, project={project_name}, created_at=<now ISO 8601 with offset, e.g. {today}T{now}±HH:MM>, updated_at=<same>, updated_by=hook) + "## Session {now}" + 3-6 bullets covering work, decisions, learnings.
 
-   Existing file: append a "## Session {now}" section. Do not edit any prior content (earlier sessions today, earlier days). You MAY (and should) rewrite the frontmatter `description` to summarize the full day now that more sessions exist.
+   Existing file: append a "## Session {now}" section. Do not edit any prior content (earlier sessions today, earlier days). You MAY (and should) rewrite the frontmatter `description` to summarize the full day now that more sessions exist; whenever you touch frontmatter, bump `updated_at` and set `updated_by: hook`.
 
    Each bullet that describes a write must include the path:
    - Vault writes (steps 1-2) → vault-relative path.

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -266,7 +266,7 @@ fn build_system_prompt(overview: &str, path_cap: usize) -> String {
     format!(
 r##"Retrieval gate for an Obsidian vault. Default to {{}}; inject only when a specific note demonstrably helps. Output ONE JSON object on a single line, no prose. `read` paths are absolute filesystem paths copied verbatim from the overview below.
 
-{{"read":["/abs/path/to/note.md"], "search":[{{"type":"...","keywords":"...","path_prefix":"...","created_after":"YYYY-MM-DD","created_before":"YYYY-MM-DD"}}]}}
+{{"read":["/abs/path/to/note.md"], "search":[{{"type":"...","keywords":"...","path_prefix":"...","created_after":"YYYY-MM-DD","created_before":"YYYY-MM-DD","updated_after":"YYYY-MM-DD","updated_before":"YYYY-MM-DD"}}]}}
 
 Both optional. Cap {path_cap} paths.
 
@@ -381,6 +381,8 @@ fn select_paths(gate_text: &str, vault: &Path, cap: usize) -> Option<Vec<String>
                 keywords: qobj.get("keywords").and_then(|v| v.as_str()),
                 created_after: qobj.get("created_after").and_then(|v| v.as_str()),
                 created_before: qobj.get("created_before").and_then(|v| v.as_str()),
+                updated_after: qobj.get("updated_after").and_then(|v| v.as_str()),
+                updated_before: qobj.get("updated_before").and_then(|v| v.as_str()),
                 limit: cap,
                 project_vault: None,
             };

--- a/src/project_init.rs
+++ b/src/project_init.rs
@@ -14,7 +14,6 @@ use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use chrono::Local;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
@@ -234,7 +233,7 @@ fn derive_description(body: &str, fallback_path: &str) -> String {
 }
 
 fn format_frontmatter(types: &[String], description: &str, project: &str) -> String {
-    let today = Local::now().format("%Y-%m-%d").to_string();
+    let now = crate::vault::timestamps::now_iso8601_local();
     let safe_desc = description.replace('\\', "\\\\").replace('"', "\\\"");
     let type_field = if types.len() == 1 {
         types[0].clone()
@@ -242,7 +241,7 @@ fn format_frontmatter(types: &[String], description: &str, project: &str) -> Str
         format!("[{}]", types.join(", "))
     };
     format!(
-        "---\ntype: {type_field}\ndescription: \"{safe_desc}\"\ncreated: {today}\nproject: {project}\n---\n\n"
+        "---\ntype: {type_field}\ndescription: \"{safe_desc}\"\ncreated_at: {now}\nupdated_at: {now}\nupdated_by: init\nproject: {project}\n---\n\n"
     )
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,7 +3,7 @@
 //! Idempotently scaffolds:
 //!   - `~/.config/obsidian-memory/` (config.env + secrets.env)
 //!   - The vault dir + Tools/Journals/Notes scaffolding
-//!   - Templates rendered with `__TODAY__` / `__VAULT_PATH__` substituted
+//!   - Templates rendered with `__NOW__` / `__TODAY__` / `__VAULT_PATH__` substituted
 //!   - Statusline wrapper + Claude Code settings.json patch
 //!   - Obsidian.app registry entry (skipped if Obsidian.app is running)
 //!
@@ -37,6 +37,7 @@ pub fn run() -> Result<i32> {
 
     let vault_path = vault_display_path();
     let today = Local::now().format("%Y-%m-%d").to_string();
+    let now = crate::vault::timestamps::now_iso8601_local();
 
     println!("obsidian-memory setup");
     println!("  plugin root: {}", plugin_root.display());
@@ -126,7 +127,10 @@ pub fn run() -> Result<i32> {
             std::fs::create_dir_all(parent)?;
         }
         let content = std::fs::read_to_string(src)?;
-        let rendered = content.replace("__TODAY__", &today).replace("__VAULT_PATH__", &vault_path);
+        let rendered = content
+            .replace("__NOW__", &now)
+            .replace("__TODAY__", &today)
+            .replace("__VAULT_PATH__", &vault_path);
         std::fs::write(&dst, rendered)?;
         println!("[+] {}", dst.display());
     }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -4,6 +4,7 @@ pub mod changes;
 pub mod frontmatter;
 pub mod overview;
 pub mod search;
+pub mod timestamps;
 pub mod walk;
 pub mod wikilinks;
 
@@ -42,6 +43,8 @@ pub fn run(args: VaultArgs) -> Result<i32> {
                     keywords: s.keywords.as_deref(),
                     created_after: s.created_after.as_deref(),
                     created_before: s.created_before.as_deref(),
+                    updated_after: s.updated_after.as_deref(),
+                    updated_before: s.updated_before.as_deref(),
                     limit: s.limit,
                     project_vault: project_vault.as_deref(),
                 },

--- a/src/vault/overview.rs
+++ b/src/vault/overview.rs
@@ -177,13 +177,18 @@ pub fn overview(vault: &Path, project: Option<&str>, mode: &str) -> Result<Strin
             None => (journals.clone(), "## Journals (recent)".to_string()),
         };
         scoped.sort_by(|a, b| {
-            // Sort by `created:` desc, fall back to filename desc.
-            let ka = a.1.get("created").cloned().filter(|s| !s.is_empty()).unwrap_or_else(|| {
-                a.0.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default()
-            });
-            let kb = b.1.get("created").cloned().filter(|s| !s.is_empty()).unwrap_or_else(|| {
-                b.0.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default()
-            });
+            // Sort by `created_at:` desc (legacy `created:` accepted), fall back
+            // to filename desc. ISO 8601 with offset and bare `YYYY-MM-DD` both
+            // sort lexicographically in chronological order, so a string compare
+            // works across the mixed-corpus migration window.
+            let ka = a.1.get("created_at").or_else(|| a.1.get("created"))
+                .cloned().filter(|s| !s.is_empty()).unwrap_or_else(|| {
+                    a.0.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default()
+                });
+            let kb = b.1.get("created_at").or_else(|| b.1.get("created"))
+                .cloned().filter(|s| !s.is_empty()).unwrap_or_else(|| {
+                    b.0.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default()
+                });
             kb.cmp(&ka)
         });
         out.push(label);
@@ -192,7 +197,7 @@ pub fn overview(vault: &Path, project: Option<&str>, mode: &str) -> Result<Strin
         }
         if scoped.len() > RECENT_JOURNAL_LIMIT {
             out.push(format!(
-                "_(+{} older — search by `created:` date)_",
+                "_(+{} older — search by `created_at:` date)_",
                 scoped.len() - RECENT_JOURNAL_LIMIT
             ));
         }

--- a/src/vault/search.rs
+++ b/src/vault/search.rs
@@ -7,11 +7,12 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use chrono::NaiveDate;
+use chrono::{DateTime, FixedOffset};
 use serde::Serialize;
 
 use crate::project_docs;
 use crate::vault::frontmatter::{note_types, read_note};
+use crate::vault::timestamps;
 use crate::vault::walk::collect_md_files;
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -21,6 +22,8 @@ pub struct SearchOpts<'a> {
     pub keywords: Option<&'a str>,
     pub created_after: Option<&'a str>,
     pub created_before: Option<&'a str>,
+    pub updated_after: Option<&'a str>,
+    pub updated_before: Option<&'a str>,
     pub limit: usize,
     pub project_vault: Option<&'a Path>,
 }
@@ -34,12 +37,16 @@ pub struct SearchHit {
     pub types: Vec<String>,
     pub description: String,
     pub project: String,
-    pub created: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub updated_by: String,
 }
 
 pub fn search(vault: &Path, opts: SearchOpts<'_>) -> Result<Vec<SearchHit>> {
-    let after = opts.created_after.and_then(parse_date);
-    let before = opts.created_before.and_then(parse_date);
+    let created_after = opts.created_after.and_then(timestamps::parse_filter);
+    let created_before = opts.created_before.and_then(timestamps::parse_filter);
+    let updated_after = opts.updated_after.and_then(timestamps::parse_filter);
+    let updated_before = opts.updated_before.and_then(timestamps::parse_filter);
 
     let kw_terms: Vec<String> = opts
         .keywords
@@ -53,6 +60,13 @@ pub fn search(vault: &Path, opts: SearchOpts<'_>) -> Result<Vec<SearchHit>> {
 
     let mut hits: Vec<(i64, SearchHit)> = Vec::new();
 
+    let bounds = TimeBounds {
+        created_after: created_after.as_ref(),
+        created_before: created_before.as_ref(),
+        updated_after: updated_after.as_ref(),
+        updated_before: updated_before.as_ref(),
+    };
+
     score_corpus(
         "personal",
         vault,
@@ -60,8 +74,7 @@ pub fn search(vault: &Path, opts: SearchOpts<'_>) -> Result<Vec<SearchHit>> {
         opts.type_,
         opts.path_prefix,
         &kw_terms,
-        after.as_ref(),
-        before.as_ref(),
+        bounds,
         &mut hits,
     );
 
@@ -74,8 +87,7 @@ pub fn search(vault: &Path, opts: SearchOpts<'_>) -> Result<Vec<SearchHit>> {
             opts.type_,
             opts.path_prefix,
             &kw_terms,
-            after.as_ref(),
-            before.as_ref(),
+            bounds,
             &mut hits,
         );
     }
@@ -90,6 +102,14 @@ pub fn search(vault: &Path, opts: SearchOpts<'_>) -> Result<Vec<SearchHit>> {
     Ok(hits.into_iter().take(opts.limit).map(|(_, h)| h).collect())
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+struct TimeBounds<'a> {
+    created_after: Option<&'a DateTime<FixedOffset>>,
+    created_before: Option<&'a DateTime<FixedOffset>>,
+    updated_after: Option<&'a DateTime<FixedOffset>>,
+    updated_before: Option<&'a DateTime<FixedOffset>>,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn score_corpus(
     corpus: &str,
@@ -98,8 +118,7 @@ fn score_corpus(
     type_: Option<&str>,
     path_prefix: Option<&str>,
     kw_terms: &[String],
-    after: Option<&NaiveDate>,
-    before: Option<&NaiveDate>,
+    bounds: TimeBounds<'_>,
     hits: &mut Vec<(i64, SearchHit)>,
 ) {
     for f in files {
@@ -126,11 +145,26 @@ fn score_corpus(
             }
         }
 
-        if after.is_some() || before.is_some() {
-            let created_str = fm_ref.and_then(|m| m.get("created")).map(|s| s.as_str()).unwrap_or("");
-            let Some(d) = parse_date(created_str) else { continue };
-            if let Some(a) = after { if &d < a { continue; } }
-            if let Some(b) = before { if &d > b { continue; } }
+        if bounds.created_after.is_some() || bounds.created_before.is_some() {
+            // Prefer `created_at`; fall back to legacy `created` so unmigrated
+            // notes still match a date filter.
+            let raw = fm_ref
+                .and_then(|m| m.get("created_at").or_else(|| m.get("created")))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let Some(d) = timestamps::parse_value(raw) else { continue };
+            if let Some(a) = bounds.created_after { if &d < a { continue; } }
+            if let Some(b) = bounds.created_before { if &d > b { continue; } }
+        }
+
+        if bounds.updated_after.is_some() || bounds.updated_before.is_some() {
+            let raw = fm_ref
+                .and_then(|m| m.get("updated_at"))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let Some(d) = timestamps::parse_value(raw) else { continue };
+            if let Some(a) = bounds.updated_after { if &d < a { continue; } }
+            if let Some(b) = bounds.updated_before { if &d > b { continue; } }
         }
 
         let score: i64 = if !kw_terms.is_empty() {
@@ -170,7 +204,12 @@ fn score_corpus(
 
         let description = fm_ref.and_then(|m| m.get("description")).cloned().unwrap_or_default();
         let project = fm_ref.and_then(|m| m.get("project")).cloned().unwrap_or_default();
-        let created = fm_ref.and_then(|m| m.get("created")).cloned().unwrap_or_default();
+        let created_at = fm_ref
+            .and_then(|m| m.get("created_at").or_else(|| m.get("created")))
+            .cloned()
+            .unwrap_or_default();
+        let updated_at = fm_ref.and_then(|m| m.get("updated_at")).cloned().unwrap_or_default();
+        let updated_by = fm_ref.and_then(|m| m.get("updated_by")).cloned().unwrap_or_default();
 
         hits.push((
             score,
@@ -181,17 +220,14 @@ fn score_corpus(
                 types,
                 description,
                 project,
-                created,
+                created_at,
+                updated_at,
+                updated_by,
             },
         ));
     }
 }
 
-pub fn parse_date(s: &str) -> Option<NaiveDate> {
-    let s = s.trim();
-    if s.is_empty() { return None; }
-    NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()
-}
 
 /// Count non-overlapping occurrences of `needle` in `haystack`.
 /// Matches Python's `str.count(sub)`.

--- a/src/vault/timestamps.rs
+++ b/src/vault/timestamps.rs
@@ -1,0 +1,86 @@
+//! Frontmatter timestamp emit + parse.
+//!
+//! Plugin-driven writes emit `created_at` / `updated_at` as ISO 8601 with
+//! local offset (e.g., `2026-05-03T22:30:00+08:00`). Filters and the
+//! search reader accept either that form or a bare `YYYY-MM-DD`, so a
+//! mixed corpus (legacy `created:` date strings + new datetime values)
+//! still compares cleanly during the migration window.
+
+use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
+
+/// Current local time formatted as ISO 8601 with offset.
+pub fn now_iso8601_local() -> String {
+    Local::now().format("%Y-%m-%dT%H:%M:%S%:z").to_string()
+}
+
+/// Parse a `created_at` / `updated_at` (or legacy `created`) frontmatter value.
+///
+/// Accepts:
+///   - RFC 3339 datetime with offset: `2026-05-03T22:30:00+08:00`, `...Z`
+///   - Bare date: `2026-05-03` — interpreted as local-midnight.
+pub fn parse_value(s: &str) -> Option<DateTime<FixedOffset>> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt);
+    }
+    parse_date_as_local_midnight(s)
+}
+
+/// Parse a CLI filter date. `--created-after 2026-05-02` → local-midnight on
+/// that date. Datetime input is also accepted for power users.
+pub fn parse_filter(s: &str) -> Option<DateTime<FixedOffset>> {
+    parse_value(s)
+}
+
+fn parse_date_as_local_midnight(s: &str) -> Option<DateTime<FixedOffset>> {
+    let date = NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()?;
+    let naive = NaiveDateTime::new(date, NaiveTime::from_hms_opt(0, 0, 0)?);
+    let local = Local.from_local_datetime(&naive).single()?;
+    Some(local.fixed_offset())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_rfc3339_with_offset() {
+        let dt = parse_value("2026-05-03T22:30:00+08:00").expect("rfc3339");
+        assert_eq!(dt.to_rfc3339(), "2026-05-03T22:30:00+08:00");
+    }
+
+    #[test]
+    fn parses_rfc3339_zulu() {
+        let dt = parse_value("2026-05-03T14:30:00Z").expect("zulu");
+        assert_eq!(dt.timezone().local_minus_utc(), 0);
+    }
+
+    #[test]
+    fn parses_bare_date_as_local_midnight() {
+        let dt = parse_value("2026-05-03").expect("bare date");
+        // Hour=0 means local midnight (offset varies with TZ but the wall-clock
+        // is always 00:00).
+        assert_eq!(dt.format("%H:%M:%S").to_string(), "00:00:00");
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert!(parse_value("").is_none());
+        assert!(parse_value("   ").is_none());
+    }
+
+    #[test]
+    fn now_has_offset_suffix() {
+        let s = now_iso8601_local();
+        // Expect a trailing offset like +08:00 or -07:00 or +00:00.
+        let last = &s[s.len().saturating_sub(6)..];
+        assert!(
+            last.starts_with('+') || last.starts_with('-'),
+            "missing offset in {s}"
+        );
+        assert_eq!(&last[3..4], ":");
+    }
+}

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,7 +1,9 @@
 ---
 type: reference
 description: "Obsidian Memory vault README — how Claude's persistent memory is organized"
-created: __TODAY__
+created_at: __NOW__
+updated_at: __NOW__
+updated_by: init
 ---
 
 # Obsidian Memory
@@ -24,8 +26,10 @@ Every note (except README files) has YAML frontmatter:
 ---
 type: preference | reference | findings | decision | learning | tool | journal
 description: "one-line hook"
-created: YYYY-MM-DD
-project: <project-name>            # only when project-scoped
+created_at: 2026-05-03T22:30:00+08:00     # ISO 8601 with local offset
+updated_at: 2026-05-03T22:30:00+08:00     # bumped on each plugin-driven write
+updated_by: skill | hook | audit | init   # the actor that wrote last
+project: <project-name>                    # only when project-scoped
 ---
 ```
 

--- a/templates/Tools/Obsidian.md
+++ b/templates/Tools/Obsidian.md
@@ -1,7 +1,9 @@
 ---
 type: tool
 description: Obsidian CLI commands, vault path, frontmatter search syntax
-created: __TODAY__
+created_at: __NOW__
+updated_at: __NOW__
+updated_by: init
 ---
 
 # Obsidian
@@ -33,15 +35,15 @@ created: __TODAY__
 
 **Syntax:**
 - `[type:learning]` — notes where `type: learning` in frontmatter
-- `[created:2026-04-27]` — notes with that exact `created` value
-- `[type:learning] [created:2026-04-27]` — AND-combined frontmatter filters
+- `[created_at:2026-04-27]` — notes whose `created_at` value starts with that date (Obsidian matches the field as a string; ISO 8601 datetimes start with the date so a date-prefix query works)
+- `[type:learning] [created_at:2026-04-27]` — AND-combined frontmatter filters
 - `path:Projects` — limit to a folder
 - `path:Projects [type:learning]` — combine path + frontmatter
 
 **Example — yesterday's learnings across all projects:**
 ```bash
 YESTERDAY=$(date -v-1d +%Y-%m-%d)
-obsidian search query="path:Projects [type:learning] [created:$YESTERDAY]" format=json
+obsidian search query="path:Projects [type:learning] [created_at:$YESTERDAY]" format=json
 ```
 
 **Related commands:**
@@ -50,5 +52,5 @@ obsidian search query="path:Projects [type:learning] [created:$YESTERDAY]" forma
 - `obsidian property:set name=<key> value=<v> type=date path=<file>` — set a field
 
 **Limitations:**
-- No native range syntax (e.g., `created:>=2026-04-01`). For ranges, loop dates and union results, or fall back to shell `grep` over frontmatter blocks.
+- No native range syntax (e.g., `created_at:>=2026-04-01`). For ranges, loop dates and union results, or use the plugin's `obsidian-memory vault search --created-after / --created-before` (which is datetime-aware).
 - Search works only on frontmatter that's been indexed by Obsidian — Obsidian.app must be running, and a `reload` may be needed after writing many files programmatically.

--- a/templates/types.md
+++ b/templates/types.md
@@ -1,7 +1,9 @@
 ---
 type: reference
 description: "Canonical definitions for the seven memory types used in vault note frontmatter."
-created: 2026-05-02
+created_at: 2026-05-02T00:00:00+08:00
+updated_at: 2026-05-03T00:00:00+08:00
+updated_by: init
 project: claude-obsidian-memory
 ---
 


### PR DESCRIPTION
## Summary

Replaces the date-only `created:` frontmatter field with three datetime-aware fields, per the design in #7:

- **`created_at`** — ISO 8601 with local offset (e.g. `2026-05-03T22:30:00+08:00`).
- **`updated_at`** — ISO 8601 with local offset; bumped on every plugin-driven write.
- **`updated_by`** — `skill | hook | audit | init`. Manual edits in Obsidian intentionally leave the fields stale (`git log` is authoritative for true last-edit semantics).

The reader path still accepts legacy `created:` (date-only) so unmigrated notes keep working. `audit --fix-frontmatter` does a one-shot migration sourced from each note's git first-commit timestamp.

### What changed

- **New module** `src/vault/timestamps.rs` — emit `now_iso8601_local()`, parse both ISO 8601 with offset and bare `YYYY-MM-DD` (date-only treated as local midnight).
- **Search** (`src/vault/search.rs`, `src/vault/mod.rs`, `src/cli.rs`):
  - reads `created_at` with fallback to legacy `created`
  - new `--updated-after` / `--updated-before` flags (datetime or date)
  - `SearchHit` JSON now exposes `created_at`, `updated_at`, `updated_by`
- **Audit** (`src/audit.rs`, `src/cli.rs`):
  - required-fields check accepts either `created_at` or legacy `created`
  - new `--fix-frontmatter` flag — rewrites each note's frontmatter, sourcing `created_at` from `git log --diff-filter=A --follow` (falls back to file mtime); adds `updated_at` + `updated_by: audit` when missing; preserves key order
- **Writers** tagged with actor:
  - `project_init.rs` → `updated_by: init`
  - `audit.rs --fix-frontmatter` → `updated_by: audit`
  - `session_end.rs` review prompt instructs the model → `updated_by: hook`
  - `skills/save-memory/SKILL.md` instructs the model → `updated_by: skill`
- **Overview** (`src/vault/overview.rs`) journal sort uses `created_at` with legacy fallback.
- **UserPromptSubmit gate** example JSON + parser support `updated_after` / `updated_before`.
- **Setup** (`src/setup.rs`) adds `__NOW__` template substitution alongside `__TODAY__`.
- **Docs/templates**: root README, FAQ, HOW-IT-WORKS, TROUBLESHOOTING, templates/README.md, templates/types.md, templates/Tools/Obsidian.md (incl. updating bracket-syntax search examples to `[created_at:...]`).

### Decisions made (per the issue's open questions)

- Field naming: **rename** `created` → `created_at` (symmetry with `updated_at`).
- Timezone: **local with offset**, not UTC.
- Backfill: **one-shot rewrite** via `audit --fix-frontmatter` (git first-commit timestamp).
- `updated_by` vocabulary: **`skill | hook | audit | init`** — no `cli` catch-all; raw `obsidian-memory` invocations don't bump.
- Filter input: bare `YYYY-MM-DD` → **local midnight**.
- Mixed corpus: legacy `created:` falls back automatically; users can migrate at their leisure.

### Migrating an existing vault

```
obsidian-memory audit --fix-frontmatter
```

## Test plan

- [x] `cargo test` — 13/13 pass (5 new in `vault::timestamps::tests`).
- [x] `cargo build --release` — clean.
- [x] Smoke-tested `audit --fix-frontmatter` on a copy of `tests/fixtures/vault` — 12 notes migrated, frontmatter key order preserved, `updated_by: audit` set.
- [x] Smoke-tested `vault search --created-after 2026-04-27` against the unmigrated fixture — legacy `created:` still matches via fallback.
- [x] Smoke-tested `vault search --updated-after 2026-04-27` — empty (correct, no `updated_at` on unmigrated notes).
- [x] Manual run on the maintainer's personal vault before merge.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)