### PR TITLE
frontmatter: add created_by actor tag (closes #4)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,6 +2,7 @@
 type: reference
 description: "FAQ about plugin behavior - session scoping, vault sharing, and related questions"
 created_at: 2026-04-30T00:00:00+08:00
+created_by: init
 updated_at: 2026-05-03T00:00:00+08:00
 updated_by: init
 project: claude-obsidian-memory

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -2,6 +2,7 @@
 type: reference
 description: "Explains the three lifecycle hooks (SessionStart, UserPromptSubmit, SessionEnd) and how the plugin operates"
 created_at: 2026-04-30T00:00:00+08:00
+created_by: init
 updated_at: 2026-05-03T00:00:00+08:00
 updated_by: init
 project: claude-obsidian-memory

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 type: reference
 description: "Overview of obsidian-memory plugin - vault-backed persistent memory for Claude Code"
 created_at: 2026-04-30T00:00:00+08:00
+created_by: init
 updated_at: 2026-05-03T00:00:00+08:00
 updated_by: init
 project: claude-obsidian-memory
@@ -16,7 +17,7 @@ A Claude Code plugin that turns a markdown directory into Claude's persistent me
 Claude Code's per-project auto-memory (`~/.claude/projects/*/memory/`) is siloed and not editable in any UI. This plugin replaces it with a vault-backed system:
 
 - **Transparent memory.** Nothing is hidden in a database or vector index — every fact the agent recalls is a file you can open and correct. Fixing a wrong memory is a text edit, not a prompt negotiation.
-- **Frontmatter as source of truth.** Every note declares `type`, `description`, `created_at`, `updated_at`, `updated_by` (and `project` when scoped). The plugin writes those fields automatically and derives everything else (recall, summaries, audits) from them — no index to maintain.
+- **Frontmatter as source of truth.** Every note declares `type`, `description`, `created_at`, `created_by`, `updated_at`, `updated_by` (and `project` when scoped). The plugin writes those fields automatically and derives everything else (recall, summaries, audits) from them — no index to maintain.
 - **Git-tracked.** Every memory write is a diff. Auto-commit on by default; auto-push opt-in.
 - **Obsidian-friendly, not Obsidian-required.** The vault is just markdown — search runs in pure Python. Obsidian.app adds a UI but no plugin-required functionality.
 - **Three lifecycle hooks + two skills.** `SessionStart` loads context, `UserPromptSubmit` runs a proactive retrieval gate (description-anchored), and two agent-driven skills cover reads and writes:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,6 +2,7 @@
 type: reference
 description: "Troubleshooting guide for common obsidian-memory plugin issues with diagnosis steps"
 created_at: 2026-04-30T00:00:00+08:00
+created_by: init
 updated_at: 2026-05-03T00:00:00+08:00
 updated_by: init
 project: claude-obsidian-memory

--- a/skills/save-memory/SKILL.md
+++ b/skills/save-memory/SKILL.md
@@ -98,8 +98,9 @@ Single type:
 type: decision
 description: "one-line hook"
 created_at: 2026-05-03T22:30:00+08:00   # ISO 8601, current local time with offset
+created_by: skill                        # this skill is the writer
 updated_at: 2026-05-03T22:30:00+08:00   # same as created_at on first write
-updated_by: skill                        # this skill is the writer
+updated_by: skill                        # same actor as created_by, on first write
 project: <name>                          # only if project-scoped
 ---
 ```
@@ -111,13 +112,14 @@ Multi-type (note genuinely spans axes — first type drives routing):
 type: [findings, decision]
 description: "one-line hook"
 created_at: 2026-05-03T22:30:00+08:00
+created_by: skill
 updated_at: 2026-05-03T22:30:00+08:00
 updated_by: skill
 project: <name>
 ---
 ```
 
-`created_at` / `updated_at` are ISO 8601 with local offset — get the value from `date +%Y-%m-%dT%H:%M:%S%z | sed 's/\(..\)$/:\1/'` (or the equivalent helper your shell exposes). Use `updated_by: skill` since save-memory is the actor. When you EXTEND an existing note (smallest edit on user correction), bump `updated_at` to now and set `updated_by: skill`; leave `created_at` alone.
+`created_at` / `updated_at` are ISO 8601 with local offset — get the value from `date +%Y-%m-%dT%H:%M:%S%z | sed 's/\(..\)$/:\1/'` (or the equivalent helper your shell exposes). Use `created_by: skill` and `updated_by: skill` since save-memory is the actor. When you EXTEND an existing note (smallest edit on user correction), bump `updated_at` to now and set `updated_by: skill`; leave `created_at` and `created_by` alone — those record the original author, not the last toucher.
 
 Always wrap `description:` in double quotes — descriptions commonly contain `:`, `[[wikilinks]]`, or `[brackets]`, all of which break unquoted YAML and silently truncate the description in the auto-overview. Escape embedded `"` as `\"`.
 

--- a/src/hook/session_end.rs
+++ b/src/hook/session_end.rs
@@ -238,7 +238,7 @@ Do steps 1-3 first. Step 4 (the journal) is written last so its bullets can refe
              → {project_dir}/<matched-folder>/<slug>.md  (with project: from the registry)
         2. Otherwise → {vault}/Notes/<slug>.md  (with `project: {project_name}` if project-scoped)
 
-   Frontmatter on every new note: type, description, created_at, updated_at, updated_by (+ project when scoped). Set `created_at` and `updated_at` to the current local time in ISO 8601 with offset (e.g. `2026-05-03T22:30:00+08:00`). Set `updated_by: hook` (this review IS the hook). When you MODIFY an existing note in step 2, bump `updated_at` to now and set `updated_by: hook`. `type:` is either a single string (`type: decision`) or a YAML list (`type: [findings, decision]`).
+   Frontmatter on every new note: type, description, created_at, created_by, updated_at, updated_by (+ project when scoped). Set `created_at` and `updated_at` to the current local time in ISO 8601 with offset (e.g. `2026-05-03T22:30:00+08:00`). Set both `created_by: hook` and `updated_by: hook` (this review IS the hook). When you MODIFY an existing note in step 2, bump `updated_at` to now and set `updated_by: hook`; do NOT touch `created_at` or `created_by`. `type:` is either a single string (`type: decision`) or a YAML list (`type: [findings, decision]`).
 
    Always wrap the `description:` value in double quotes (e.g. `description: "one-line hook"`). Descriptions often contain `:`, `[[wikilinks]]`, or `[brackets]` — unquoted, these break YAML parsing. Escape any embedded `"` as `\"`. This rule also applies when you rewrite an existing note's `description` (step 2) or the journal's day-summary `description` (step 4).
 
@@ -270,7 +270,7 @@ Do steps 1-3 first. Step 4 (the journal) is written last so its bullets can refe
 
    Journals are scoped one-file-per-project-per-day: the directory `{project_name}/` segregates this project's day from any other project's day. Use the `Write` tool — it creates parent directories automatically.
 
-   New file: frontmatter (type=journal, description=<one-line day summary>, project={project_name}, created_at=<now ISO 8601 with offset, e.g. {today}T{now}±HH:MM>, updated_at=<same>, updated_by=hook) + "## Session {now}" + 3-6 bullets covering work, decisions, learnings.
+   New file: frontmatter (type=journal, description=<one-line day summary>, project={project_name}, created_at=<now ISO 8601 with offset, e.g. {today}T{now}±HH:MM>, created_by=hook, updated_at=<same>, updated_by=hook) + "## Session {now}" + 3-6 bullets covering work, decisions, learnings.
 
    Existing file: append a "## Session {now}" section. Do not edit any prior content (earlier sessions today, earlier days). You MAY (and should) rewrite the frontmatter `description` to summarize the full day now that more sessions exist; whenever you touch frontmatter, bump `updated_at` and set `updated_by: hook`.
 

--- a/src/project_init.rs
+++ b/src/project_init.rs
@@ -241,7 +241,7 @@ fn format_frontmatter(types: &[String], description: &str, project: &str) -> Str
         format!("[{}]", types.join(", "))
     };
     format!(
-        "---\ntype: {type_field}\ndescription: \"{safe_desc}\"\ncreated_at: {now}\nupdated_at: {now}\nupdated_by: init\nproject: {project}\n---\n\n"
+        "---\ntype: {type_field}\ndescription: \"{safe_desc}\"\ncreated_at: {now}\ncreated_by: init\nupdated_at: {now}\nupdated_by: init\nproject: {project}\n---\n\n"
     )
 }
 

--- a/src/vault/search.rs
+++ b/src/vault/search.rs
@@ -38,6 +38,7 @@ pub struct SearchHit {
     pub description: String,
     pub project: String,
     pub created_at: String,
+    pub created_by: String,
     pub updated_at: String,
     pub updated_by: String,
 }
@@ -208,6 +209,7 @@ fn score_corpus(
             .and_then(|m| m.get("created_at").or_else(|| m.get("created")))
             .cloned()
             .unwrap_or_default();
+        let created_by = fm_ref.and_then(|m| m.get("created_by")).cloned().unwrap_or_default();
         let updated_at = fm_ref.and_then(|m| m.get("updated_at")).cloned().unwrap_or_default();
         let updated_by = fm_ref.and_then(|m| m.get("updated_by")).cloned().unwrap_or_default();
 
@@ -221,6 +223,7 @@ fn score_corpus(
                 description,
                 project,
                 created_at,
+                created_by,
                 updated_at,
                 updated_by,
             },

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,6 +2,7 @@
 type: reference
 description: "Obsidian Memory vault README — how Claude's persistent memory is organized"
 created_at: __NOW__
+created_by: init
 updated_at: __NOW__
 updated_by: init
 ---
@@ -27,6 +28,7 @@ Every note (except README files) has YAML frontmatter:
 type: preference | reference | findings | decision | learning | tool | journal
 description: "one-line hook"
 created_at: 2026-05-03T22:30:00+08:00     # ISO 8601 with local offset
+created_by: skill | hook | audit | init   # the actor that originally wrote (absent on legacy notes)
 updated_at: 2026-05-03T22:30:00+08:00     # bumped on each plugin-driven write
 updated_by: skill | hook | audit | init   # the actor that wrote last
 project: <project-name>                    # only when project-scoped

--- a/templates/Tools/Obsidian.md
+++ b/templates/Tools/Obsidian.md
@@ -2,6 +2,7 @@
 type: tool
 description: Obsidian CLI commands, vault path, frontmatter search syntax
 created_at: __NOW__
+created_by: init
 updated_at: __NOW__
 updated_by: init
 ---

--- a/templates/types.md
+++ b/templates/types.md
@@ -2,6 +2,7 @@
 type: reference
 description: "Canonical definitions for the seven memory types used in vault note frontmatter."
 created_at: 2026-05-02T00:00:00+08:00
+created_by: init
 updated_at: 2026-05-03T00:00:00+08:00
 updated_by: init
 project: claude-obsidian-memory


### PR DESCRIPTION
## Summary

Builds on #7 (PR #16) by adding `created_by` — the missing piece for distinguishing skill-authored vs hook-authored notes that the issue calls out as a quality-auditing and observability blocker.

> ⚠️ **Stacked on #16** (`fix/issue-7`). Targets that branch as the base, so the diff stays scoped to just the `created_by` work. Merge #16 first, then rebase this onto `main`.

### Design

- `created_by` records the **original author** at note creation. Same vocabulary as `updated_by`: `skill | hook | audit | init`.
- It is **never** bumped on subsequent edits. `updated_by` already covers last-toucher; `created_by` covers original author. Together they tell the full story.
- **No backfill**, per the scope decision. Legacy notes and notes migrated by `audit --fix-frontmatter` (from #7) leave `created_by` absent — the original author is unknown and `git blame` is the fallback.
- Audit's required-fields check intentionally does NOT require `created_by` — would falsely flag every legacy note.

### What changed

- `src/project_init.rs` writes `created_by: init` in fresh frontmatter blocks.
- `src/hook/session_end.rs` review prompt: model is now told to set `created_by: hook` on every NEW note (journal + step-1 captures), and to leave `created_at` / `created_by` alone when modifying an existing note.
- `skills/save-memory/SKILL.md`: example frontmatter now shows `created_by: skill`; instructions clarify the "set once on creation, never on edit" rule.
- `src/vault/search.rs` `SearchHit` exposes `created_by` (empty string when absent).
- Docs / templates updated: root README, FAQ, HOW-IT-WORKS, TROUBLESHOOTING, templates/README.md, templates/types.md, templates/Tools/Obsidian.md.

### Out of scope (explicit)

- No `--created-by` / `--updated-by` filter flags. Can be added later if needed; not required to close #4.
- No backfill. Confirmed in the issue thread.

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo test` — 13/13 pass.
- [x] Smoke-tested a fresh note with `created_by: skill` — appears verbatim in `vault search --json` output, alongside `created_at` / `updated_at` / `updated_by`.
- [ ] Live SessionEnd run on the maintainer's vault to verify the model honors the new instruction.

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)